### PR TITLE
fix: Change regex to match images with _and_ without closing tag

### DIFF
--- a/Classes/Service/AbstractMailerService.php
+++ b/Classes/Service/AbstractMailerService.php
@@ -93,7 +93,7 @@ abstract class AbstractMailerService
 	 * @return string
 	 */
 	protected function attachHtmlInlineImages($html) {
-		return preg_replace_callback('#(<img [^>]*[ ]?src=")([^"]+)("[^>]*/>)#', array($this, 'attachHtmlInlineImage'), $html);
+		return preg_replace_callback('#(<img [^>]*[ ]?src=")([^"]+)("[^>]*>)#', array($this, 'attachHtmlInlineImage'), $html);
 	}
 
     /**


### PR DESCRIPTION
The regex in `attachHtmlInlineImages()` did not match self closing image tags `>` which it should. Void elements are HTML5 standard - however annoyingly.