### PR TITLE
fix: embedded images not shown in email 

### DIFF
--- a/Classes/Service/AbstractMailerService.php
+++ b/Classes/Service/AbstractMailerService.php
@@ -152,7 +152,7 @@ abstract class AbstractMailerService
         if ($this->mailSettings['attachEmbeddedImages']) {
             $part = new DataPart(new File(urldecode($path)));
             $this->processedMessage->addPart($part->asInline());
-            $path = 'cid' . $part->getContentId();
+            $path = 'cid:' . $part->getContentId();
         }
 
         return sprintf('%s%s%s', $imgTagStart, $path, $imgTagEnd);


### PR DESCRIPTION
### Description
Embedded images were not shown in the email due to faulty part-data cid, it was missing a colon :
This issue might have come up after the Repo was updated to use the Symfony-Mailer.

### Type of Change

- [x]  Bug fix (non-breaking change which fixes an issue)

### Related Issue
No issue created

### How Has This Been Tested?
Installed the fork with the fix in a local test project with embedded image configuration:
```
   localEmbed: true
   attachEmbeddedImages: true

```Sent test emails and verified:

Images are embedded correctly in the email body
CID references in the source match the MIME part headers
No broken image references in email clients