### PR TITLE
fix: faulty type doc for createMessage method

### DIFF
--- a/Classes/Service/AbstractMailerService.php
+++ b/Classes/Service/AbstractMailerService.php
@@ -77,7 +77,7 @@ abstract class AbstractMailerService
     /**
      * Creates new email message object and stores it as processedMessage
      *
-     * @return Message
+     * @return Email
      */
     public function createMessage()
     {


### PR DESCRIPTION
# Fix: Correct @return type for createMessage()
### Problem
`createMessage()` declared `@return Message` but instantiates and returns `Symfony\Component\Mime\Email`

```php
// Classes/Service/AbstractMailerService.php
$message = new Email(); // ← actual type
...
return $message;
```

Both classes are imported at the top of the file:

```php
use Symfony\Component\Mime\Email;
use Symfony\Component\Mime\Message;
```

Email extends Message — so the doc was not wrong at runtime, but it caused IDEs and static analyzers to infer Message as return type. This hides all Email-specific methods (`subject()`, `addTo()`, etc.) from autocomplete and type-checked call sites.

