### PR TITLE
Allow for the usage of Transports/DSN not directly configured in Symfony Mailer

### DIFF
--- a/Classes/Aspect/MailerTransportAspect.php
+++ b/Classes/Aspect/MailerTransportAspect.php
@@ -17,13 +17,16 @@ use Symfony\Component\Mailer\Transport;
 /**
  * @Flow\Aspect
  */
-class DebuggingAspect
+class MailerTransportAspect
 {
     #[Flow\InjectConfiguration(package: 'FormatD.Mailer', type: 'Settings')]
     protected array $settings;
 
     #[Flow\InjectConfiguration(path: 'mailer', package: 'Neos.SymfonyMailer')]
     protected array $symfonyMailerSettings;
+
+    #[Flow\InjectConfiguration(path: 'mailer.additionalTransportFactories', package: 'FormatD.Mailer')]
+    protected array $additionalTransportFactories = [];
 
     protected ?Mailer $mailer = null;
 
@@ -33,25 +36,38 @@ class DebuggingAspect
     public function decorateMailer(JoinPointInterface $joinPoint): MailerInterface
     {
         if (!($this->settings['interceptAll']['active'] ?? false) && !($this->settings['bccAll']['active'] ?? false)) {
-            if ($this->mailer === null && ($this->symfonyMailerSettings['dsn'] ?? null) === 'fd-mailer') {
-                $this->mailer = new Mailer(new FdMailerTransport());
-            } else {
-                $this->mailer = $joinPoint->getAdviceChain()->proceed($joinPoint);
+            if ($this->mailer === null) {
+                $dsn = $this->symfonyMailerSettings['dsn'] ?? null;
+                $this->mailer = $dsn === 'fd-mailer'
+                    ? new Mailer(new FdMailerTransport())
+                    : new Mailer($this->createTransport((string)$dsn));
             }
             return $this->mailer;
-		}
+        }
 
         if ($this->mailer === null) {
             $dsn = $this->symfonyMailerSettings['dsn'];
             if ($dsn === 'fd-mailer') {
                 $actualTransport = new FdMailerTransport();
             } else {
-                $actualTransport = Transport::fromDsn($this->symfonyMailerSettings['dsn']);
+                $actualTransport = $this->createTransport($dsn);
             }
             $interceptingTransport = new InterceptingTransport($actualTransport);
             $this->mailer = new Mailer($interceptingTransport);
         }
 
         return $this->mailer;
+    }
+
+    protected function createTransport(string $dsn): \Symfony\Component\Mailer\Transport\TransportInterface
+    {
+        $factories = iterator_to_array(Transport::getDefaultFactories());
+        foreach ($this->additionalTransportFactories as $factoryClass) {
+            if (class_exists($factoryClass)) {
+                $factories[] = new $factoryClass();
+            }
+        }
+
+        return (new Transport($factories))->fromString($dsn);
     }
 }

--- a/Classes/Aspect/MailerTransportAspect.php
+++ b/Classes/Aspect/MailerTransportAspect.php
@@ -10,6 +10,7 @@ use FormatD\Mailer\Transport\FdMailerTransport;
 use FormatD\Mailer\Transport\InterceptingTransport;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Transport;
@@ -62,9 +63,10 @@ class MailerTransportAspect
     protected function createTransport(string $dsn): \Symfony\Component\Mailer\Transport\TransportInterface
     {
         $factories = iterator_to_array(Transport::getDefaultFactories());
+        $httpClient = HttpClient::create();
         foreach ($this->additionalTransportFactories as $factoryClass) {
             if (class_exists($factoryClass)) {
-                $factories[] = new $factoryClass();
+                $factories[] = new $factoryClass(null, $httpClient);
             }
         }
 

--- a/Classes/Aspect/MailerTransportAspect.php
+++ b/Classes/Aspect/MailerTransportAspect.php
@@ -62,8 +62,8 @@ class MailerTransportAspect
 
     protected function createTransport(string $dsn): \Symfony\Component\Mailer\Transport\TransportInterface
     {
-        $factories = iterator_to_array(Transport::getDefaultFactories());
         $httpClient = HttpClient::create();
+        $factories = iterator_to_array(Transport::getDefaultFactories(client: $httpClient));
         foreach ($this->additionalTransportFactories as $factoryClass) {
             if (class_exists($factoryClass)) {
                 $factories[] = new $factoryClass(null, $httpClient);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,6 +2,7 @@ Neos:
   SymfonyMailer:
     mailer:
       dsn: 'fd-mailer'
+      additionalTransportFactories: []
 
 FormatD:
   Mailer:


### PR DESCRIPTION
As described here: https://github.com/neos/symfonymailer/issues/5 it is not possible to install a different transport for the Symfony Mailer and use it with the Neos Symfony Mailer Package. 

This change adds `additionalTransportFactories` that will then be able to be used in the DSN configuration 